### PR TITLE
Add `npc` command to `mythal`

### DIFF
--- a/lib/mythal.rb
+++ b/lib/mythal.rb
@@ -1,7 +1,9 @@
-require "mythal"
+# require "mythal"
 require "thor"
 require "procto"
+require "mythal/version"
 require "mythal/roll"
+require "mythal/npc"
 
 module Mythal
   class CLI < Thor
@@ -10,6 +12,12 @@ module Mythal
 
     def roll(*args)
       puts Mythal::Roll.call(*args)
+    end
+
+    desc "npc", "generate a random npc, e.g. 'a half-orc barbarian'"
+
+    def npc
+      puts Mythal::Npc.call
     end
   end
 end

--- a/lib/mythal.rb
+++ b/lib/mythal.rb
@@ -5,7 +5,9 @@ require "mythal/roll"
 
 module Mythal
   class CLI < Thor
+
     desc "roll", "roll some number of dice, plus modifiers e.g. 1d20, or 3d8 + 4"
+
     def roll(*args)
       puts Mythal::Roll.call(*args)
     end

--- a/lib/mythal/npc.rb
+++ b/lib/mythal/npc.rb
@@ -1,0 +1,11 @@
+module Mythal
+  class Npc
+    include Procto.call
+
+    def initialize
+    end
+
+    def call
+    end
+  end
+end

--- a/lib/mythal/npc.rb
+++ b/lib/mythal/npc.rb
@@ -2,10 +2,73 @@ module Mythal
   class Npc
     include Procto.call
 
-    def initialize
+    def call
+      character_description
     end
 
-    def call
+    private
+
+    def character_description
+      trait + " " + race + " " + dnd_class
+    end
+
+    def trait
+      [
+        "bombastic",
+        "scrappy",
+        "nimble",
+        "argumentative",
+        "grumpy",
+        "drunk",
+        "overly friendly",
+        "touchy",
+        "flirtatious",
+        "ponderous",
+        "inquisitive",
+        "skeptical",
+        "ruminating",
+        "articulate",
+        "ejaculatory (in terms of sound)",
+        "timid",
+        "bold",
+        "dubious",
+        "overly sympathetic",
+        "boorish",
+        "feckless",
+        "nefarious",
+        "honorable",
+        "spasmodic",
+      ].sample
+    end
+
+    def race
+      [
+        "orc",
+        "half-orc",
+        "human",
+        "elf",
+        "half-elf",
+        "halfling",
+        "dragonborn",
+        "tiefling",
+        "dwarf",
+        "gnome",
+      ].sample
+    end
+
+    def dnd_class
+      [
+        "fighter",
+        "rogue",
+        "wizard",
+        "sorceror",
+        "druid",
+        "cleric",
+        "bard",
+        "monk",
+        "warlock",
+        "paladin",
+      ].sample
     end
   end
 end

--- a/test/mythal_test.rb
+++ b/test/mythal_test.rb
@@ -1,11 +1,15 @@
 require "test_helper"
 
 class MythalTest < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Mythal::VERSION
+  extend Minitest::Spec::DSL
+
+  subject do
+    Mythal
   end
 
-  # def test_it_does_something_useful
-  #   assert false
-  # end
+  describe "version" do
+    it "has a version number" do
+      refute_nil ::Mythal::VERSION
+    end
+  end
 end

--- a/test/npc_test.rb
+++ b/test/npc_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class Mythal::NpcTest < Minitest::Test
+  extend Minitest::Spec::DSL
+
+  subject do
+    ::Mythal::Npc
+
+    describe "::call" do
+      it "responds" do
+        assert respond_to :call
+      end
+    end
+  end
+end

--- a/test/npc_test.rb
+++ b/test/npc_test.rb
@@ -4,12 +4,16 @@ class Mythal::NpcTest < Minitest::Test
   extend Minitest::Spec::DSL
 
   subject do
-    ::Mythal::Npc
+    Mythal::Npc
+  end
 
-    describe "::call" do
-      it "responds" do
-        assert respond_to :call
-      end
+  describe "::call" do
+    it "responds" do
+      assert_respond_to subject, :call
+    end
+
+    it "returns a string" do
+      assert subject.call.is_a?(String)
     end
   end
 end


### PR DESCRIPTION
Add command to generate npc characteristics

Adds the following command: 'mythal npc', which will generate
characteristics for an NPC for D&D 5th edition of the form

[trait] [race] [class]