### PR TITLE
Add features to NPC command

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -47,3 +47,12 @@ dnd_classes:
   - monk
   - warlock
   - paladin
+
+npc_stats_by_challenge_rating:
+  'Headers': [proficiency_bonus, armor_class, hit_points, attack_bonus, damage_per_round, save_dc]
+  '0': [2, 13, 1..6, 3, 1..2, 13]
+  '1/8': [2, 13, 7..35, 3, 2..3, 13]
+  '1/4': [2, 13, 36..49, 3, 4..5, 13]
+  '1/2': [2, 13, 50..70, 3, 6..8, 13]
+  '1': [2, 13, 71..85, 3, 9..14, 13]
+  '2': [2, 13, 16..100, 3, 15..20, 13]

--- a/lib/mythal.rb
+++ b/lib/mythal.rb
@@ -1,30 +1,11 @@
-# require "mythal"
 require "thor"
 require "procto"
 require "mythal/version"
 require "mythal/config"
 require "mythal/roll"
+require "mythal/stats"
 require "mythal/npc"
+require "mythal/cli"
 
 module Mythal
-  class CLI < Thor
-
-    desc "roll", "roll some number of dice, plus modifiers e.g. 1d20, or 3d8 + 4"
-
-    def roll(*args)
-      puts Mythal::Roll.call(*args).message
-    end
-
-    desc "npc", "generate a random npc, e.g. 'a half-orc barbarian'"
-
-    def npc
-      puts Mythal::Npc.call(config: config)
-    end
-
-    private
-
-    def config
-      @config ||= Mythal::Config.new
-    end
-  end
 end

--- a/lib/mythal.rb
+++ b/lib/mythal.rb
@@ -1,3 +1,6 @@
+module Mythal
+end
+
 require "thor"
 require "procto"
 require "mythal/version"
@@ -6,6 +9,3 @@ require "mythal/roll"
 require "mythal/stats"
 require "mythal/npc"
 require "mythal/cli"
-
-module Mythal
-end

--- a/lib/mythal/cli.rb
+++ b/lib/mythal/cli.rb
@@ -1,0 +1,22 @@
+module Mythal
+  class CLI < Thor
+
+    desc "roll", "roll some number of dice, plus modifiers e.g. 1d20, or 3d8 + 4"
+
+    def roll(*args)
+      puts Mythal::Roll.call(*args).message
+    end
+
+    desc "npc", "generate a random npc, e.g. 'a half-orc barbarian'"
+
+    def npc
+      puts Mythal::Npc.call(config: config).message
+    end
+
+    private
+
+    def config
+      @config ||= Mythal::Config.new
+    end
+  end
+end

--- a/lib/mythal/cli.rb
+++ b/lib/mythal/cli.rb
@@ -13,16 +13,9 @@ module Mythal
 
     def npc
       puts Mythal::Npc.call(
-        config: config,
         challenge_rating: options[:challenge_rating],
         user_overrides: options[:options]&.transform_keys(&:to_sym),
       ).message
-    end
-
-    private
-
-    def config
-      @config ||= Mythal::Config.new
     end
   end
 end

--- a/lib/mythal/cli.rb
+++ b/lib/mythal/cli.rb
@@ -8,9 +8,15 @@ module Mythal
     end
 
     desc "npc", "generate a random npc, e.g. 'a half-orc barbarian'"
+    method_option :challenge_rating, type: :string, aliases: "--cr"
+    method_option :options, type: :hash, aliases: "-o"
 
     def npc
-      puts Mythal::Npc.call(config: config).message
+      puts Mythal::Npc.call(
+        config: config,
+        challenge_rating: options[:challenge_rating],
+        user_overrides: options[:options]&.transform_keys(&:to_sym),
+      ).message
     end
 
     private

--- a/lib/mythal/config.rb
+++ b/lib/mythal/config.rb
@@ -3,32 +3,36 @@ require "pathname"
 
 module Mythal
   class Config
-    def initialize(user_overrides: {})
-      @user_overrides = user_overrides
-    end
+    class << self
+      attr_reader :settings
 
-    def traits
-      config["traits"]
-    end
+      def config
+        @config ||= YAML.load(File.read(config_file))
+      end
 
-    def races
-      config["races"]
-    end
+      def dnd_classes
+        config["dnd_classes"]
+      end
 
-    def dnd_classes
-      config["dnd_classes"]
-    end
+      def npc_stats_by_challenge_rating
+        config["npc_stats_by_challenge_rating"]
+      end
 
-    def config
-      @config ||= user_overrides.empty? ? YAML.load(File.read(config_file)) : user_overrides
-    end
+      def races
+        config["races"]
+      end
 
-    private
+      def traits
+        config["traits"]
+      end
 
-    attr_reader :user_overrides
+      private
 
-    def config_file
-      Pathname.new(File.expand_path("../../../config.yml", __FILE__))
+      attr_reader :user_overrides
+
+      def config_file
+        Pathname.new(File.expand_path("../../../config.yml", __FILE__))
+      end
     end
   end
 end

--- a/lib/mythal/npc.rb
+++ b/lib/mythal/npc.rb
@@ -2,8 +2,7 @@ module Mythal
   class Npc
     include Procto.call
 
-    def initialize(config:, challenge_rating: "1/4", user_overrides: {})
-      @config = config
+    def initialize(challenge_rating: "1/4", user_overrides: {})
       @challenge_rating = challenge_rating
       @user_overrides = user_overrides
     end
@@ -42,15 +41,20 @@ module Mythal
         ---
         Armor Class: #{stats.armor_class}
         Hit Points: #{stats.hit_points}
-        Speed: #{stats.speed}ft
         Attack: +#{stats.attack_bonus}
         Damage: #{stats.damage_per_round} slashing
+        Speed: #{stats.speed}ft
+        Challenge Rating: #{stats.challenge_rating}
         ---
       OUTPUT
     end
 
     private
 
-    attr_reader :config, :user_overrides, :challenge_rating
+    attr_reader :user_overrides, :challenge_rating
+
+    def config
+      Mythal::Config
+    end
   end
 end

--- a/lib/mythal/npc.rb
+++ b/lib/mythal/npc.rb
@@ -7,7 +7,25 @@ module Mythal
     end
 
     def call
-      character_description
+      self
+    end
+
+    def stats
+      @stats ||= Mythal::Stats.new
+    end
+
+    def message
+      <<~OUTPUT
+        ---
+        #{character_description}
+        ---
+        Armor Class: #{stats.armor_class}
+        Hit Points: #{stats.hit_points}
+        Speed: #{stats.speed}ft
+        Attack: +#{stats.attack_bonus}
+        Damage: #{stats.damage_per_round} slashing
+        ---
+      OUTPUT
     end
 
     private
@@ -18,16 +36,16 @@ module Mythal
       trait + " " + race + " " + dnd_class
     end
 
-    def trait
-      config.traits.sample
+    def dnd_class
+      config.dnd_classes.sample
     end
 
     def race
       config.races.sample
     end
 
-    def dnd_class
-      config.dnd_classes.sample
+    def trait
+      config.traits.sample
     end
   end
 end

--- a/lib/mythal/npc.rb
+++ b/lib/mythal/npc.rb
@@ -2,8 +2,10 @@ module Mythal
   class Npc
     include Procto.call
 
-    def initialize(config:)
+    def initialize(config:, challenge_rating: "1/4", user_overrides: {})
       @config = config
+      @challenge_rating = challenge_rating
+      @user_overrides = user_overrides
     end
 
     def call
@@ -11,7 +13,26 @@ module Mythal
     end
 
     def stats
-      @stats ||= Mythal::Stats.new
+      @stats ||= Mythal::Stats.new(
+        challenge_rating: challenge_rating,
+        options: (user_overrides || {}),
+      )
+    end
+
+    def character_description
+      trait + " " + race + " " + dnd_class
+    end
+
+    def dnd_class
+      config.dnd_classes.sample
+    end
+
+    def race
+      config.races.sample
+    end
+
+    def trait
+      config.traits.sample
     end
 
     def message
@@ -30,22 +51,6 @@ module Mythal
 
     private
 
-    attr_reader :config
-
-    def character_description
-      trait + " " + race + " " + dnd_class
-    end
-
-    def dnd_class
-      config.dnd_classes.sample
-    end
-
-    def race
-      config.races.sample
-    end
-
-    def trait
-      config.traits.sample
-    end
+    attr_reader :config, :user_overrides, :challenge_rating
   end
 end

--- a/lib/mythal/stats.rb
+++ b/lib/mythal/stats.rb
@@ -20,7 +20,7 @@ module Mythal
     attr_reader :challenge_rating, :options
 
     def initialize(challenge_rating: "1/4", options: {})
-      @challenge_rating = challenge_rating
+      @challenge_rating = challenge_rating || "1/4"
       @options = options
       post_initialize
     end

--- a/lib/mythal/stats.rb
+++ b/lib/mythal/stats.rb
@@ -1,0 +1,73 @@
+module Mythal
+  class Stats
+    VALID_ATTRS = %i[
+      challenge_rating
+      proficiency_bonus
+      armor_class
+      hit_points
+      attack_bonus
+      damage_per_round
+      save_dc
+      speed
+      str
+      dex
+      con
+      int
+      wis
+      cha
+    ]
+
+    attr_reader :challenge_rating, :options
+
+    def initialize(challenge_rating: "1/4", options: {})
+      @challenge_rating = challenge_rating
+      @options = options
+      post_initialize
+    end
+
+    def attributes
+      {
+        challenge_rating: challenge_rating,
+        proficiency_bonus: 2,
+        armor_class: 13,
+        hit_points: init_hit_points,
+        damage_per_round: 5,
+        attack_bonus: 2,
+        save_dc: 13,
+        speed: 30,
+        str: 15,
+        dex: 14,
+        con: 13,
+        int: 12,
+        wis: 10,
+        cha: 8,
+      }.merge(user_overrides)
+    end
+
+    def init_hit_points
+      default_hit_points[challenge_rating].to_a.sample
+    end
+
+    def user_overrides
+      options.select do |k, _v|
+        VALID_ATTRS.include?(k)
+      end
+    end
+
+    def default_hit_points
+      {
+        "0" => 1..6,
+        "1/8" => 7..35,
+        "1/4" => 36..49,
+        "1/2" => 50..70,
+        "1" => 71..85,
+      }
+    end
+
+    def post_initialize
+      attributes.each do |attr_name, attr_value|
+        define_singleton_method(attr_name) { attr_value }
+      end
+    end
+  end
+end

--- a/lib/mythal/version.rb
+++ b/lib/mythal/version.rb
@@ -1,3 +1,3 @@
 module Mythal
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -21,13 +21,17 @@ class Mythal::CLITest < Minitest::Test
     end
 
     it "prints out a roll with a negative modifier" do
-      assert_output(/rolling d20... \d+\n\d+ \- 5\n\d+/) { subject.roll("1d20 - 5") }
+      assert_output(/rolling d20... \d+\n\d+ \- 5\n\d+/) { subject.roll("2d20 - 5") }
     end
   end
 
   describe "#npc" do
     it "responds" do
       assert_respond_to subject, :npc
+    end
+
+    it "prints out a message" do
+      assert_output(/\w+/) { subject.npc }
     end
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -4,18 +4,42 @@ class Mythal::ConfigTest < Minitest::Test
   extend Minitest::Spec::DSL
 
   subject do
-    Mythal::Config.new
+    Mythal::Config
   end
 
-  describe "#config" do
+  describe "::config" do
     it "returns a parsed defaults object" do
       assert_kind_of Hash, subject.config
     end
+  end
 
-    it "returns arrays for each key" do
-      subject.config.each do |_k, v|
-        assert_kind_of Array, v
-      end
+  describe "::races" do
+    it "returns an array of races" do
+      races = subject.races
+      assert_kind_of Array, races
+      assert_includes races, "orc"
+    end
+  end
+
+  describe "::dnd_classes" do
+    it "returns an array of dnd_classes" do
+      dnd_classes = subject.dnd_classes
+      assert_kind_of Array, dnd_classes
+      assert_includes dnd_classes, "fighter"
+    end
+  end
+
+  describe "::traits" do
+    it "returns an array of traits" do
+      traits = subject.traits
+      assert_kind_of Array, traits
+      assert_includes traits, "bombastic"
+    end
+  end
+
+  describe "::npc_stats_by_challenge_rating" do
+    it "returns a hash of stats" do
+      assert_kind_of Hash, subject.npc_stats_by_challenge_rating
     end
   end
 end

--- a/test/npc_test.rb
+++ b/test/npc_test.rb
@@ -4,15 +4,7 @@ class Mythal::NpcTest < Minitest::Test
   extend Minitest::Spec::DSL
 
   subject do
-    Mythal::Npc.call(config: config)
-  end
-
-  let(:config) do
-    Mythal::Config.new(user_overrides: {
-      "traits" => ["funky"],
-      "races" => ["gnome"],
-      "dnd_classes" => ["druid"],
-    })
+    Mythal::Npc.call
   end
 
   describe "responds to cli interface" do
@@ -55,12 +47,12 @@ class Mythal::NpcTest < Minitest::Test
       end
 
       it "generates a 1/4 challenge rating NPC if no CR is specified" do
-        npc = subject.call(config: config)
+        npc = subject.call
         assert_equal "1/4", npc.stats.challenge_rating
       end
 
       it "generates an appropriate challenge rating if CR is specified" do
-        npc = subject.call(config: config, challenge_rating: "1/8")
+        npc = subject.call(challenge_rating: "1/8")
         assert_equal "1/8", npc.stats.challenge_rating
       end
     end

--- a/test/npc_test.rb
+++ b/test/npc_test.rb
@@ -15,9 +15,45 @@ class Mythal::NpcTest < Minitest::Test
     })
   end
 
-  describe "::call" do
-    it "returns a string describing an NPC" do
-      assert_equal "funky gnome druid", subject
+  describe "responds to cli interface" do
+    it "responds to #message" do
+      response_obj = subject
+      assert_respond_to response_obj, :message
+    end
+  end
+
+  describe "#message" do
+    it "generates a string describing an NPC" do
+      message = subject.message
+
+      assert_match(/Armor Class/, message)
+      assert_match(/Hit Points/, message)
+      assert_match(/Speed/, message)
+    end
+  end
+
+  describe "#stats" do
+    it "generates a stat block for an NPC" do
+      stats = subject.stats
+      assert_respond_to stats, :hit_points
+      assert_respond_to stats, :armor_class
+      assert_respond_to stats, :speed
+
+      named_stats = %i[
+        hit_points
+        armor_class
+        speed
+        proficiency_bonus
+        damage_per_round
+      ]
+
+      named_stats.each do |stat|
+        assert_respond_to stats, stat
+      end
+    end
+
+    it "generates a value for hitpoints between 1 and 10" do
+      assert subject.stats.hit_points.between?(36, 49)
     end
   end
 end

--- a/test/npc_test.rb
+++ b/test/npc_test.rb
@@ -35,9 +35,6 @@ class Mythal::NpcTest < Minitest::Test
   describe "#stats" do
     it "generates a stat block for an NPC" do
       stats = subject.stats
-      assert_respond_to stats, :hit_points
-      assert_respond_to stats, :armor_class
-      assert_respond_to stats, :speed
 
       named_stats = %i[
         hit_points
@@ -52,8 +49,20 @@ class Mythal::NpcTest < Minitest::Test
       end
     end
 
-    it "generates a value for hitpoints between 1 and 10" do
-      assert subject.stats.hit_points.between?(36, 49)
+    describe "challenge_rating" do
+      subject do
+        Mythal::Npc
+      end
+
+      it "generates a 1/4 challenge rating NPC if no CR is specified" do
+        npc = subject.call(config: config)
+        assert_equal "1/4", npc.stats.challenge_rating
+      end
+
+      it "generates an appropriate challenge rating if CR is specified" do
+        npc = subject.call(config: config, challenge_rating: "1/8")
+        assert_equal "1/8", npc.stats.challenge_rating
+      end
     end
   end
 end

--- a/test/roll_test.rb
+++ b/test/roll_test.rb
@@ -7,6 +7,13 @@ class Mythal::RollTest < Minitest::Test
     Mythal::Roll
   end
 
+  describe "cli interface" do
+    it "responds to #message" do
+      response_obj = subject.call("1d20")
+      assert_respond_to response_obj, :message
+    end
+  end
+
   describe "::call" do
     it "returns a dice result object" do
       result = subject.call("1d20")

--- a/test/stats_test.rb
+++ b/test/stats_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "mythal/stats"
+
+class Mythal::StatsTest < Minitest::Test
+  extend Minitest::Spec::DSL
+
+  subject do
+    Mythal::Stats.new(options: params)
+  end
+
+  describe "#attributes" do
+    describe "when no options are passed" do
+      let(:params) { {} }
+
+      it "returns a hash of attributes" do
+        expected = {
+          challenge_rating: "1/4",
+          proficiency_bonus: 2,
+          armor_class: 13,
+          damage_per_round: 5,
+          attack_bonus: 2,
+          save_dc: 13,
+          speed: 30,
+          str: 15,
+          dex: 14,
+          con: 13,
+          int: 12,
+          wis: 10,
+          cha: 8,
+        }
+
+        dynamic_keys = [:hit_points]
+        actual = subject.attributes.reject { |k| dynamic_keys.include?(k) }
+
+        assert_equal expected, actual
+      end
+    end
+
+    describe "when options are passed" do
+      let(:params) do
+        {
+          challenge_rating: 1,
+          proficiency_bonus: 2,
+          armor_class: 13,
+          hit_points: 40,
+          damage_per_round: 5,
+          attack_bonus: 3,
+          save_dc: 12,
+          speed: 30,
+          str: 15,
+          dex: 14,
+          con: 13,
+          int: 12,
+          wis: 10,
+          cha: 8,
+        }
+      end
+
+      it "returns a hash of attributes with user overrides" do
+        assert_equal params, subject.attributes
+      end
+    end
+  end
+end

--- a/test/stats_test.rb
+++ b/test/stats_test.rb
@@ -5,12 +5,67 @@ class Mythal::StatsTest < Minitest::Test
   extend Minitest::Spec::DSL
 
   subject do
-    Mythal::Stats.new(options: params)
+    Mythal::Stats.new(options: options)
+  end
+
+  describe "#challenge_rating" do
+    subject do
+      Mythal::Stats
+    end
+
+    it "defaults to a challenge rating of 1/4 if none is specified" do
+      assert_equal "1/4", subject.new.challenge_rating
+    end
+
+    it "returns the specified challenge rating if it exists" do
+      assert_equal "1", subject.new(challenge_rating: "1").challenge_rating
+    end
+
+    it "accepts challenge ratings in the range 0..30" do
+      (0..30).each do |i|
+        cr = i.to_s
+        assert_equal cr, subject.new(challenge_rating: cr).challenge_rating
+      end
+    end
+
+    it "accepts challenge ratings as string fractions `1/8`, `1/4` and `1/2`" do
+      ["1/8", "1/4", "1/2"].each do |cr|
+        assert_equal cr, subject.new(challenge_rating: cr).challenge_rating
+      end
+    end
+  end
+
+  describe "#hit_points" do
+    subject do
+      Mythal::Stats
+    end
+
+    let(:cr_half_hp) { (50..70) }
+    let(:cr_quarter_hp) { (36..49) }
+
+    describe "when hit_points are directly specified" do
+      it "returns the passed-in hit points when they are specified" do
+        stats = subject.new(options: { hit_points: 27 })
+        assert_equal 27, stats.hit_points
+      end
+
+      it "generates a hit point value based on CR when not specified" do
+        stats = subject.new(challenge_rating: "1/2")
+        assert stats.hit_points.between?(cr_half_hp.min, cr_half_hp.max)
+      end
+    end
+
+    describe "when hit_points are not specified" do
+      it "generates a hit point value based on a default CR of 1/4" do
+        stats = subject.new(challenge_rating: nil)
+        assert stats.hit_points.between?(cr_quarter_hp.min, cr_quarter_hp.max)
+      end
+    end
   end
 
   describe "#attributes" do
     describe "when no options are passed" do
-      let(:params) { {} }
+      let(:options) { {} }
 
       it "returns a hash of attributes" do
         expected = {
@@ -37,7 +92,7 @@ class Mythal::StatsTest < Minitest::Test
     end
 
     describe "when options are passed" do
-      let(:params) do
+      let(:options) do
         {
           challenge_rating: 1,
           proficiency_bonus: 2,
@@ -57,7 +112,7 @@ class Mythal::StatsTest < Minitest::Test
       end
 
       it "returns a hash of attributes with user overrides" do
-        assert_equal params, subject.attributes
+        assert_equal options, subject.attributes
       end
     end
   end

--- a/test/stats_test.rb
+++ b/test/stats_test.rb
@@ -1,16 +1,21 @@
 require "test_helper"
-require "mythal/stats"
 
 class Mythal::StatsTest < Minitest::Test
   extend Minitest::Spec::DSL
 
-  subject do
-    Mythal::Stats.new(options: options)
-  end
-
   describe "#challenge_rating" do
     subject do
       Mythal::Stats
+    end
+
+    let(:valid_challenge_ratings) do
+      %w[
+        0
+        1/8
+        1/4
+        1/2
+        1
+      ]
     end
 
     it "defaults to a challenge rating of 1/4 if none is specified" do
@@ -21,17 +26,15 @@ class Mythal::StatsTest < Minitest::Test
       assert_equal "1", subject.new(challenge_rating: "1").challenge_rating
     end
 
-    it "accepts challenge ratings in the range 0..30" do
-      (0..30).each do |i|
-        cr = i.to_s
+    it "accepts challenge ratings as string fractions `1/8`, `1/4` and `1/2`" do
+      valid_challenge_ratings.each do |cr|
         assert_equal cr, subject.new(challenge_rating: cr).challenge_rating
       end
     end
 
-    it "accepts challenge ratings as string fractions `1/8`, `1/4` and `1/2`" do
-      ["1/8", "1/4", "1/2"].each do |cr|
-        assert_equal cr, subject.new(challenge_rating: cr).challenge_rating
-      end
+    it "falls back to the default if a passed-in challenge rating is invalid" do
+      stat_block = subject.new(challenge_rating: 9_999)
+      assert_equal "1/4", stat_block.challenge_rating
     end
   end
 
@@ -64,30 +67,32 @@ class Mythal::StatsTest < Minitest::Test
   end
 
   describe "#attributes" do
+    subject do
+      Mythal::Stats.new(options: options)
+    end
+
     describe "when no options are passed" do
       let(:options) { {} }
 
       it "returns a hash of attributes" do
-        expected = {
-          challenge_rating: "1/4",
-          proficiency_bonus: 2,
-          armor_class: 13,
-          damage_per_round: 5,
-          attack_bonus: 2,
-          save_dc: 13,
-          speed: 30,
-          str: 15,
-          dex: 14,
-          con: 13,
-          int: 12,
-          wis: 10,
-          cha: 8,
-        }
+        expected_keys = %i[
+          challenge_rating
+          proficiency_bonus
+          armor_class
+          damage_per_round
+          attack_bonus
+          hit_points
+          save_dc
+          speed
+          str
+          dex
+          con
+          int
+          wis
+          cha
+        ]
 
-        dynamic_keys = [:hit_points]
-        actual = subject.attributes.reject { |k| dynamic_keys.include?(k) }
-
-        assert_equal expected, actual
+        assert_equal expected_keys.sort, subject.attributes.keys.sort
       end
     end
 


### PR DESCRIPTION
Adds functionality to the `npc` command, including new command line arguments. New functionality includes:

* ability to generate full stat blocks with hit points, armor class, speed, damage per round, and challenge rating
* ability to override any and all stats when generating an NPC
* dynamic calculations of stat blocks based on challenge rating
* refactor of `config` service